### PR TITLE
Refactored BaseOpModes and the location of System to fix broken refactoring

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/BaseAutonomousOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/BaseAutonomousOpMode.java
@@ -15,7 +15,7 @@ import org.firstinspires.ftc.teamcode.config.ConfigParser;
  * Created by EvanCoulson on 10/11/17.
  */
 
-public abstract class BaseOpMode extends LinearOpMode
+public abstract class BaseAutonomousOpMode extends LinearOpMode
 {
     public ConfigParser config;
     public MecanumDriveSystem driveSystem;
@@ -26,7 +26,7 @@ public abstract class BaseOpMode extends LinearOpMode
     public ClawSystemNoMergeConflictPlease claw;
     public ParallelLiftSystem parallelLiftSystem;
 
-    public BaseOpMode(String opModeName)
+    public BaseAutonomousOpMode(String opModeName)
     {
         config = new ConfigParser(opModeName + ".omc");
         telemetry.setMsTransmissionInterval(200);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/CompetitionOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/CompetitionOpMode.java
@@ -1,9 +1,7 @@
 package org.firstinspires.ftc.teamcode.autonomous;
 
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-import com.sun.tools.javac.comp.Flow;
 
-import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.robot.systems.ParallelLiftSystem;
 import org.firstinspires.ftc.teamcode.robot.systems.PixySystem;
 
@@ -12,7 +10,7 @@ import org.firstinspires.ftc.teamcode.robot.systems.PixySystem;
  */
 
 @Autonomous(name = "CompetitionOpMode", group = "Bot")
-public class CompetitionOpMode extends BaseOpMode
+public class CompetitionOpMode extends BaseAutonomousOpMode
 {
     private int zone;
     private int inchesToReferenceBoxNonAudience;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/PitCrewOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/PitCrewOpMode.java
@@ -9,7 +9,7 @@ import org.firstinspires.ftc.teamcode.robot.systems.ParallelLiftSystem;
  */
 
 @Autonomous(name = "PitCrewOpMode", group = "Bot")
-public class PitCrewOpMode extends BaseOpMode
+public class PitCrewOpMode extends BaseAutonomousOpMode
 {
 
     public static final int TIME = 1000;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/VuforiaBaseOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/VuforiaBaseOpMode.java
@@ -17,7 +17,7 @@ import org.firstinspires.ftc.robotcore.external.matrices.OpenGLMatrix;
  */
 
 
-public abstract class VuforiaBaseOpMode extends BaseOpMode
+public abstract class VuforiaBaseOpMode extends BaseAutonomousOpMode
 {
 
     protected static class Target

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/VuforiaOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/VuforiaOpMode.java
@@ -19,7 +19,7 @@ import org.firstinspires.ftc.teamcode.R;
 
 @Autonomous(name = "VuforiaOP", group = "Bot")
 @Disabled
-public class VuforiaOpMode extends BaseOpMode
+public class VuforiaOpMode extends BaseAutonomousOpMode
 {
 
     public VuforiaOpMode()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/onStartOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/onStartOpMode.java
@@ -7,7 +7,7 @@ import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
  */
 
 @Autonomous(name = "onStartOpMode", group = "Bot")
-public class onStartOpMode extends BaseOpMode
+public class onStartOpMode extends BaseAutonomousOpMode
 {
     public onStartOpMode()
     {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ClawSystemNoMergeConflictPlease.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ClawSystemNoMergeConflictPlease.java
@@ -8,6 +8,7 @@ import com.qualcomm.robotcore.hardware.DcMotor;
 import org.firstinspires.ftc.teamcode.robot.components.servos.DcMotorServo;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.config.ConfigParser;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 /**
  * Created by jacks on 1/8/2018.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ElevatorSystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ElevatorSystem.java
@@ -7,6 +7,7 @@ import com.qualcomm.robotcore.hardware.DigitalChannel;
 import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 /**
  * Created by jacks on 10/20/2017.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/Eye.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/Eye.java
@@ -15,7 +15,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.VuforiaLocalizer;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackable;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackableDefaultListener;
 import org.firstinspires.ftc.robotcore.external.navigation.VuforiaTrackables;
-import org.firstinspires.ftc.teamcode.robot.systems.System;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 /**
  * Created by Steven Abbott on 9/27/2017.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/IMUSystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/IMUSystem.java
@@ -5,6 +5,7 @@ import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 
 import org.firstinspires.ftc.robotcore.external.navigation.*;
 import org.firstinspires.ftc.teamcode.logger.LoggingService;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 /**
  * This is NOT an opmode.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/MecanumDriveSystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/MecanumDriveSystem.java
@@ -11,6 +11,7 @@ import org.firstinspires.ftc.teamcode.hardware.dcmotors.MotorType;
 import org.firstinspires.ftc.teamcode.robot.components.GearChain;
 import org.firstinspires.ftc.teamcode.robot.components.motors.GearedWheelMotor;
 import org.firstinspires.ftc.teamcode.logger.LoggingService;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 import org.firstinspires.ftc.teamcode.scale.*;
 
 import java.util.Arrays;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ParallelLiftSystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/ParallelLiftSystem.java
@@ -7,6 +7,7 @@ import com.qualcomm.robotcore.hardware.DigitalChannel;
 import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 /**
  * Created by jacks on 11/28/2017.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/PixySystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/PixySystem.java
@@ -6,6 +6,7 @@ import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.Servo;
 
 import org.firstinspires.ftc.teamcode.hardware.pixycam.PixyCam;
+import org.firstinspires.ftc.teamcode.robot.systems.common.System;
 
 @Autonomous(name = "PixySystem", group = "Bot")
 public class PixySystem extends System

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/common/System.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/systems/common/System.java
@@ -1,4 +1,4 @@
-package org.firstinspires.ftc.teamcode.robot.systems;
+package org.firstinspires.ftc.teamcode.robot.systems.common;
 
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.hardware.HardwareMap;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/BaseTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/BaseTeleOpMode.java
@@ -15,7 +15,7 @@ import org.firstinspires.ftc.teamcode.logger.LoggingService;
  * Created by EvanCoulson on 10/11/17.
  */
 
-public abstract class BaseOpMode extends OpMode
+public abstract class BaseTeleOpMode extends OpMode
 {
     protected final ConfigParser config;
     protected Controller controller1;
@@ -27,7 +27,7 @@ public abstract class BaseOpMode extends OpMode
     protected Logger logger;
 
 
-    public BaseOpMode(String opModeName)
+    public BaseTeleOpMode(String opModeName)
     {
         this.logger = new Logger(this, opModeName);
         logger.setLoggingServices(LoggingService.FILE);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/ControllerOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/ControllerOpMode.java
@@ -2,24 +2,18 @@ package org.firstinspires.ftc.teamcode.teleop;
 
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
-import com.qualcomm.robotcore.eventloop.opmode.OpMode;
-import com.qualcomm.robotcore.util.ElapsedTime;
-import com.qualcomm.robotcore.util.RobotLog;
-
-import org.firstinspires.ftc.robotcore.external.Func;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.hardware.controller.TriggerType;
 import org.firstinspires.ftc.teamcode.robot.systems.ClawSystemNoMergeConflictPlease;
 import org.firstinspires.ftc.teamcode.robot.systems.ElevatorSystem;
 import org.firstinspires.ftc.teamcode.robot.systems.ParallelLiftSystem;
-import org.firstinspires.ftc.teamcode.robot.systems.PixySystem;
 import org.firstinspires.ftc.teamcode.util.Handler;
 
 /**
  * Created by jacks on 10/5/2017.
  */
 @TeleOp(name = "ContollerOpMode", group = "TeleOp")
-public class ControllerOpMode extends BaseOpMode
+public class ControllerOpMode extends BaseTeleOpMode
 {
     private ClawSystemNoMergeConflictPlease claw;
     private ElevatorSystem elevator;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMecanum.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleOpMecanum.java
@@ -44,7 +44,7 @@ import org.firstinspires.ftc.teamcode.robot.systems.MecanumDriveSystem;
  */
 
 @TeleOp(name = "TeleOpMecanum", group = "TeleOp")
-public class TeleOpMecanum extends BaseOpMode
+public class TeleOpMecanum extends BaseTeleOpMode
 {
 
     private MecanumDriveSystem driveSystem;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleopTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/teleop/TeleopTest.java
@@ -10,7 +10,7 @@ import org.firstinspires.ftc.teamcode.robot.systems.IMUSystem;
 import org.firstinspires.ftc.teamcode.logger.LoggingService;
 
 @TeleOp(name = "TeleOpTest", group = "TeleOp")
-public class TeleopTest extends BaseOpMode
+public class TeleopTest extends BaseTeleOpMode
 {
     private IMUSystem imu;
 


### PR DESCRIPTION
I renamed and shuffled the locations of both BaseOpModes and the System base class to fix bad refactoring which made other classes unable to identify and import them. (this is the pull request for 2018. the first time I accidentally made one merging to the 2017 repo)